### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*.*.*"        # parte al push di un tag tipo v0.1.0
+
+permissions:
+  id-token: write       # NECESSARIO per OIDC
+  contents: read
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - run: python -m pip install --upgrade build
+
+      - run: python -m build          # genera dist/*.whl e dist/*.tar.gz
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1
+        with:
+          # se nel form hai indicato "Environment name = pypi":
+          #  environment: pypi
+          skip-existing: true


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to publish releases to PyPI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68876bcb9234832a9b16107a57ec15b1